### PR TITLE
Update to the new plugin api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
+jdk:
+ - oraclejdk8
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.23
-script: 
-  - bundle exec rspec spec
+ - jruby-1.7.25
+script:
+ - bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
-# 2.0.4
+## 3.0.0
+  - Update to the new plugin api
+  - relax constraints on the logstash-core-plugin-api
+  - Update .travis.yml
+
+## 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.3
+
+## 2.0.3
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/outputs/datadog.rb
+++ b/lib/logstash/outputs/datadog.rb
@@ -53,9 +53,6 @@ class LogStash::Outputs::Datadog < LogStash::Outputs::Base
 
   public
   def receive(event)
-    
-
-
     dd_event = Hash.new
     dd_event['title'] = event.sprintf(@title)
     dd_event['text'] = event.sprintf(@text)
@@ -72,7 +69,7 @@ class LogStash::Outputs::Datadog < LogStash::Outputs::Base
     if @dd_tags
       tagz = @dd_tags.collect {|x| event.sprintf(x) }
     else
-      tagz = event["tags"]
+      tagz = event.get("tags")
     end
     dd_event['tags'] = tagz if tagz
 

--- a/logstash-output-datadog.gemspec
+++ b/logstash-output-datadog.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-output-datadog'
-  s.version         = '2.0.4'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you send events (for now. soon metrics) to DataDogHQ based on Logstash events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
- update .travis.yml
- update to use the new plugin api
- relax logstash-core-plugin-api constraints
