### PR TITLE
Allow use of field variables in alert_type

### DIFF
--- a/lib/logstash/outputs/datadog.rb
+++ b/lib/logstash/outputs/datadog.rb
@@ -29,7 +29,7 @@ class LogStash::Outputs::Datadog < LogStash::Outputs::Base
   config :source_type_name, :validate => ["nagios", "hudson", "jenkins", "user", "my apps", "feed", "chef", "puppet", "git", "bitbucket", "fabric", "capistrano"], :default => "my apps"
 
   # Alert type
-  config :alert_type, :validate => ["info", "error", "warning", "success"]
+  config :alert_type, :validate => :string
 
   # Priority
   config :priority, :validate => ["normal", "low"]


### PR DESCRIPTION
Remove validation of specific alert_types.  This validation already exists in DataDog api, and is limiting the usefulness of this plugin. 
resolves #9

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
