### PR TITLE
Change api_key type to password to prevent leaking in debug logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 3.0.5
+  - Change `api_key` config type to `password` to prevent leaking it in debug logs [#19](https://github.com/logstash-plugins/logstash-output-datadog/pull/19)
+
+## 3.0.5
   - Docs: Set the default_codec doc attribute.
 
 ## 3.0.4

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -36,7 +36,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-alert_type>> |<<string,string>>, one of `["info", "error", "warning", "success"]`|No
-| <<plugins-{type}s-{plugin}-api_key>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-api_key>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-date_happened>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-dd_tags>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-priority>> |<<string,string>>, one of `["normal", "low"]`|No
@@ -62,7 +62,7 @@ Alert type
 ===== `api_key` 
 
   * This is a required setting.
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 Your DatadogHQ API key

--- a/lib/logstash/outputs/datadog.rb
+++ b/lib/logstash/outputs/datadog.rb
@@ -14,7 +14,7 @@ class LogStash::Outputs::Datadog < LogStash::Outputs::Base
   config_name "datadog"
 
   # Your DatadogHQ API key
-  config :api_key, :validate => :string, :required => true
+  config :api_key, :validate => :password, :required => true
 
   # Title
   config :title, :validate => :string, :default => "Logstash event for %{host}"
@@ -75,7 +75,7 @@ class LogStash::Outputs::Datadog < LogStash::Outputs::Base
 
     @logger.debug("DataDog event", :dd_event => dd_event)
 
-    request = Net::HTTP::Post.new("#{@uri.path}?api_key=#{@api_key}")
+    request = Net::HTTP::Post.new("#{@uri.path}?api_key=#{@api_key.value}")
 
     begin
       request.body = LogStash::Json.dump(dd_event)

--- a/logstash-output-datadog.gemspec
+++ b/logstash-output-datadog.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-datadog'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to DataDogHQ based on Logstash events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/datadog_spec.rb
+++ b/spec/outputs/datadog_spec.rb
@@ -1,1 +1,20 @@
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/outputs/datadog"
+
+describe LogStash::Outputs::Datadog do
+
+  let(:plugin) { described_class.new(config) }
+
+  describe "debugging `api_key`" do
+    let(:config) {{ 'dd_tags' => %w[foo bar],
+                    "api_key" => "$ecre&-key"
+      }
+    }
+
+    it "should not show origin value" do
+      expect(plugin.logger).to receive(:debug).with('<password>')
+      plugin.logger.send(:debug, plugin.api_key.to_s)
+    end
+  end
+
+end


### PR DESCRIPTION
When running Logstash with `--config.debug` option, `api_key` maybe seen in the debug logs. This change changes its type to `password` to prevent leaking it in the debug logs.

- Closes #18 