### PR TITLE
Actual changelog version update. :facepalm:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.5
+## 3.0.6
   - Change `api_key` config type to `password` to prevent leaking it in debug logs [#19](https://github.com/logstash-plugins/logstash-output-datadog/pull/19)
 
 ## 3.0.5


### PR DESCRIPTION
https://github.com/logstash-plugins/logstash-output-datadog/pull/19 PR didn't actually change changelog version, sorry!
